### PR TITLE
Hotfix:  API throwing build errors

### DIFF
--- a/app/api/lobby/[lobbyId]/route.ts
+++ b/app/api/lobby/[lobbyId]/route.ts
@@ -113,7 +113,7 @@ export async function PATCH(request: Request, { params }: PATCHOptions) {
   });
 }
 
-export async function singleGetLobby({ lobbyId }: { lobbyId: string }): Promise<Lobby> {
+async function singleGetLobby({ lobbyId }: { lobbyId: string }): Promise<Lobby> {
   const supabase = createRouteHandlerSupabaseClient<Database>({
     headers,
     cookies,

--- a/app/api/lobby/[lobbyId]/route.ts
+++ b/app/api/lobby/[lobbyId]/route.ts
@@ -162,13 +162,7 @@ async function addUserToLobby({
   if (error) throw new Error(error.message);
 }
 
-export async function joinLobby({
-  lobbyId,
-  userId,
-}: {
-  lobbyId: string;
-  userId: string;
-}): Promise<void> {
+async function joinLobby({ lobbyId, userId }: { lobbyId: string; userId: string }): Promise<void> {
   const lobby = await singleGetLobby({ lobbyId });
 
   const emptyPlayerPosition = ['player_1', 'player_2', 'player_3', 'player_4'].find(
@@ -180,7 +174,7 @@ export async function joinLobby({
   await addUserToLobby({ lobbyId, userId, playerPosition: emptyPlayerPosition });
 }
 
-export async function changeLobbyAnnounce({
+async function changeLobbyAnnounce({
   lobbyId,
   announce,
 }: {

--- a/app/api/lobby/[lobbyId]/route.ts
+++ b/app/api/lobby/[lobbyId]/route.ts
@@ -126,7 +126,7 @@ async function singleGetLobby({ lobbyId }: { lobbyId: string }): Promise<Lobby> 
   return lobby;
 }
 
-export async function deleteLobby({ lobbyId }: { lobbyId: string }): Promise<void> {
+async function deleteLobby({ lobbyId }: { lobbyId: string }): Promise<void> {
   const supabase = createRouteHandlerSupabaseClient<Database>({
     headers,
     cookies,

--- a/app/api/lobby/[lobbyId]/route.ts
+++ b/app/api/lobby/[lobbyId]/route.ts
@@ -34,7 +34,7 @@ export const revalidate = 0;
 export async function GET(request: Request, { params }: GETOptions) {
   const lobbyId = params.lobbyId;
 
-  const lobby = await getLobby({ lobbyId });
+  const lobby = await singleGetLobby({ lobbyId });
 
   return new Response(JSON.stringify(lobby), {
     headers: {
@@ -113,7 +113,7 @@ export async function PATCH(request: Request, { params }: PATCHOptions) {
   });
 }
 
-export async function getLobby({ lobbyId }: { lobbyId: string }): Promise<Lobby> {
+export async function singleGetLobby({ lobbyId }: { lobbyId: string }): Promise<Lobby> {
   const supabase = createRouteHandlerSupabaseClient<Database>({
     headers,
     cookies,
@@ -169,7 +169,7 @@ export async function joinLobby({
   lobbyId: string;
   userId: string;
 }): Promise<void> {
-  const lobby = await getLobby({ lobbyId });
+  const lobby = await singleGetLobby({ lobbyId });
 
   const emptyPlayerPosition = ['player_1', 'player_2', 'player_3', 'player_4'].find(
     (playerPosition) => !lobby[playerPosition as keyof Lobby]


### PR DESCRIPTION
so in an api route you export functions GET, POST and so on, you can also export other functions so you can use the logic in serverside pages. BUT god forgive if you export the function and don't use it in a server page.

so if anything other than function GET, POST, PUT etc,.. is exported from route.ts you have to import it somewhere or it refuses to build.